### PR TITLE
Package the plugin according to Grafana docs && change plugin ID && bump version to 0.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,11 +17,11 @@ aliases:
       only: master
 
 defaults: &defaults
-  working_directory: ~/kentik-app
+  working_directory: ~/kentik-grafana-app
   docker:
     - image: circleci/node:10.15.3-stretch
   environment:
-    PLUGIN_NAME: kentik-app
+    PLUGIN_NAME: kentik-grafana-app
 
 jobs:
   build:
@@ -41,8 +41,8 @@ jobs:
             # create zip file
             cd ~
             echo "Creating ZIP"
-            cp -r ${PLUGIN_NAME}/dist/ ./tmp/${PLUGIN_NAME}
-            cd tmp/
+            cp -r ${PLUGIN_NAME}/dist/ /tmp/${PLUGIN_NAME}
+            cd /tmp
             zip \
               -r ${PLUGIN_NAME}-${VERSION}.zip \
               ${PLUGIN_NAME}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,22 +41,20 @@ jobs:
             # create zip file
             cd ~
             echo "Creating ZIP"
+            cp -r ${PLUGIN_NAME}/dist/ ./tmp/${PLUGIN_NAME}
+            cd tmp/
             zip \
-              -x ${PLUGIN_NAME}/.git/**\* \
-              -x ${PLUGIN_NAME}/node_modules/**\* \
-              -r /tmp/${PLUGIN_NAME}-${VERSION}.zip \
+              -r ${PLUGIN_NAME}-${VERSION}.zip \
               ${PLUGIN_NAME}
             # create tar file
             echo "Creating TAR"
             tar \
-              --exclude .git \
-              --exclude node_modules \
-              -zcvf /tmp/${PLUGIN_NAME}-${VERSION}.tar.gz \
+              -zcvf ${PLUGIN_NAME}-${VERSION}.tar.gz \
               ${PLUGIN_NAME}
             # create artifacts
             mkdir -p ~/${PLUGIN_NAME}/artifacts
-            mv /tmp/${PLUGIN_NAME}-${VERSION}.zip ~/${PLUGIN_NAME}/artifacts/
-            mv /tmp/${PLUGIN_NAME}-${VERSION}.tar.gz ~/${PLUGIN_NAME}/artifacts/
+            mv ${PLUGIN_NAME}-${VERSION}.zip ~/${PLUGIN_NAME}/artifacts/
+            mv ${PLUGIN_NAME}-${VERSION}.tar.gz ~/${PLUGIN_NAME}/artifacts/
           no_output_timeout: 5m
       - save_cache:
           name: Save NPM Package Cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,11 +17,11 @@ aliases:
       only: master
 
 defaults: &defaults
-  working_directory: ~/kentik-grafana-app
+  working_directory: ~/kentik-connect-app
   docker:
     - image: circleci/node:10.15.3-stretch
   environment:
-    PLUGIN_NAME: kentik-grafana-app
+    PLUGIN_NAME: kentik-connect-app
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.5.0] - 2021-07-14
+## [1.5.0] - 2021-08-06
 
 ### Breaking changes
 
 Plugin ID is changed according to [Grafana convention](https://grafana.com/docs/grafana/v7.5/developers/plugins/legacy/review-guidelines/#pluginjson): `kentik-app` -> `kentik-connect-app`.
 
-**You'll need to remove the old plugin version manually. Please refer to the updated installation instructions before updating.** Otherwise, there will be 2 versions of Kentik Connect Pro App installed.
+**Please refer to the updated installation instructions before updating.** 
+It's important to **remove the existing plugin** and **enable the plugin in Grafana again**.
 
 ### Changed
 - Plugin is packaged according to [Grafana docs](https://grafana.com/docs/grafana/latest/developers/plugins/package-a-plugin/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.5.0] - 2021-07-14
+
+### Breaking changes
+
+Plugin ID is changed according to [Grafana convention](https://grafana.com/docs/grafana/v7.5/developers/plugins/legacy/review-guidelines/#pluginjson): `kentik-app` -> `kentik-connect-app`.
+
+**You'll need to remove the old plugin version manually. Please refer to the updated installation instructions before updating.** Otherwise, there will be 2 versions of Kentik Connect Pro App installed.
+
+### Changed
+- Plugin is packaged according to [Grafana docs](https://grafana.com/docs/grafana/latest/developers/plugins/package-a-plugin/)
+
 ## [1.4.2] - 2021-05-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,6 @@ Plugin ID is changed according to [Grafana convention](https://grafana.com/docs/
 **Please refer to the updated installation instructions before updating.** 
 It's important to **remove the existing plugin** and **enable the plugin in Grafana again**.
 
-### Changed
-- Plugin is packaged according to [Grafana docs](https://grafana.com/docs/grafana/latest/developers/plugins/package-a-plugin/)
-
 ## [1.4.2] - 2021-05-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Grafana docs about plugin installation: https://grafana.com/docs/plugins/install
 
 #### Install / update plugin
 ```bash
-grafana-cli --pluginUrl "https://github.com/kentik/kentik-grafana-app/releases/download/v1.4.2/kentik-app-1.4.2.zip" plugins install kentik-app
+grafana-cli remove kentik-app # if you're updating from version < 1.5.0
+grafana-cli --pluginUrl "https://github.com/kentik/kentik-grafana-app/releases/download/v1.5.0/kentik-connect-app-1.5.0.zip" plugins install kentik-connect-app
 sudo systemctl restart grafana-server
 ```
 
@@ -54,19 +55,19 @@ sudo systemctl restart grafana-server
   - For Grafana installed using Standalone Linux Binaries or source:
     - `<GRAFANA_PATH>/data/plugins`
 
-- Download kentik-app
+- Remove old kentik-connect-app (if it exists)
 ```bash
-wget https://github.com/kentik/kentik-grafana-app/releases/download/v1.4.2/kentik-app-1.4.2.tar.gz
+rm -rf kentik-app kentik-connect-app-*
 ```
 
-- Remove old kentik-app (if it exists)
+- Download kentik-connect-app
 ```bash
-rm -rf kentik-app
+wget https://github.com/kentik/kentik-grafana-app/releases/download/v1.5.0/kentik-connect-app-1.5.0.tar.gz
 ```
 
 - Unpack downloaded files
 ```bash
-tar -zxvf kentik-app-1.4.2.tar.gz
+tar -zxvf kentik-connect-app-1.5.0.tar.gz
 ```
 
 - Restart Grafana
@@ -83,7 +84,7 @@ You can install Kentik App to Grafana in Docker passing it as the environment va
 ```bash
 docker run \
   -p 3000:3000 \
-  -e "GF_INSTALL_PLUGINS=https://github.com/kentik/kentik-grafana-app/releases/download/v1.4.2/kentik-app-1.4.2.zip;kentik-grafana-app" \
+  -e "GF_INSTALL_PLUGINS=https://github.com/kentik/kentik-grafana-app/releases/download/v1.5.0/kentik-connect-app-1.5.0.zip;kentik-connect-app" \
   grafana/grafana
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ grafana-cli --pluginUrl "https://github.com/kentik/kentik-grafana-app/releases/d
 sudo systemctl restart grafana-server
 ```
 
+**Note: if you're updating from version < 1.5.0, you'll need to enable the plugin in Grafana again**
+
 ### Manual installation
 
 - Navigate to Grafana plugins directory:
@@ -76,6 +78,8 @@ tar -zxvf kentik-connect-app-1.5.0.tar.gz
   - For Grafana installed using Standalone Linux Binaries or source:
     - Stop any running instances of grafana-server
     - Start grafana-server: `cd <GRAFANA_PATH> && ./bin/grafana-server`
+
+**Note: if you're updating from version < 1.5.0, you'll need to enable the plugin in Grafana again**
 
 ### Docker installation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![CircleCI](https://circleci.com/gh/grafana/kentik-app.svg?style=svg)](https://circleci.com/gh/grafana/kentik-app)
-[![David Dependancy Status](https://david-dm.org/grafana/kentik-app.svg)](https://david-dm.org/grafana/kentik-app)
-[![David Dev Dependency Status](https://david-dm.org/grafana/kentik-app/dev-status.svg)](https://david-dm.org/grafana/kentik-app/?type=dev)
+[![CircleCI](https://circleci.com/gh/kentik/kentik-grafana-app.svg?style=svg)](https://circleci.com/gh/kentik/kentik-grafana-app)
+[![David Dependancy Status](https://david-dm.org/kentik/kentik-grafana-app.svg)](https://david-dm.org/kentik/kentik-grafana-app)
+[![David Dev Dependency Status](https://david-dm.org/kentik/kentik-grafana-app/dev-status.svg)](https://david-dm.org/kentik/kentik-grafana-app/?type=dev)
 
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ grafana:
   ports:
     - "3000:3000"
   volumes:
-    - ./dist:/var/lib/grafana/plugins/kentik-app
+    - ./dist:/var/lib/grafana/plugins/kentik-connect-app
     - ./provisioning:/etc/grafana/provisioning
   environment:
     - TERM=linux

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kentik-grafana-app",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "kentik-app",
+  "name": "kentik-grafana-app",
   "version": "1.4.2",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kentik-grafana-app",
   "private": true,
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "",
   "scripts": {
     "build": "webpack --config build/webpack.prod.conf.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kentik-app",
+  "name": "kentik-grafana-app",
   "private": true,
   "version": "1.4.2",
   "description": "",
@@ -11,12 +11,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/grafana/kentik-app.git"
+    "url": "git+https://github.com/kentik/kentik-grafana-app.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/grafana/kentik-app/issues"
+    "url": "https://github.com/kentik/kentik-grafana-app/issues"
   },
   "devDependencies": {
     "@babel/core": "7.4.5",

--- a/src/components/add_device.ts
+++ b/src/components/add_device.ts
@@ -42,12 +42,12 @@ export class AddDeviceCtrl {
       ips.push(ip.ip);
     });
     this.device.sending_ips = ips.join();
-    const resp = await this.backendSrv.post(`/api/plugin-proxy/kentik-app/api/v5/device`, this.device);
+    const resp = await this.backendSrv.post(`/api/plugin-proxy/kentik-connect-app/api/v5/device`, this.device);
     if ('err' in resp) {
       this.alertSrv.set('Device Add failed.', resp.err, 'error');
       throw new Error(`Device Add failed: ${resp.err}`);
     } else {
-      this.$location.url('/plugins/kentik-app/page/device-list');
+      this.$location.url('/plugins/kentik-connect-app/page/device-list');
     }
   }
 }

--- a/src/components/device_details.html
+++ b/src/components/device_details.html
@@ -120,7 +120,7 @@
         </div>
       </div>
       <button type="submit" class="btn btn-success" ng-click="ctrl.update()">Update Device</button>
-      <a class="btn btn-link" href="plugins/kentik-app/page/device-list" ng-click="ctrl.cancel();">Cancel</a>
+      <a class="btn btn-link" href="plugins/kentik-connect-app/page/device-list" ng-click="ctrl.cancel();">Cancel</a>
     </form>
   </div>
 

--- a/src/components/device_details.ts
+++ b/src/components/device_details.ts
@@ -39,7 +39,7 @@ export class DeviceDetailsCtrl {
 
   async fetchDevice(deviceId: string): Promise<void> {
     const resp = await this.backendSrv.get(
-      `/api/plugin-proxy/kentik-app/api/v5/device/${deviceId}`
+      `/api/plugin-proxy/kentik-connect-app/api/v5/device/${deviceId}`
     );
     this.device = resp.device;
     this.updateDeviceDTO();
@@ -81,7 +81,7 @@ export class DeviceDetailsCtrl {
 
     try {
       const resp = await this.backendSrv.put(
-        `/api/plugin-proxy/kentik-app/api/v5/device/${this.deviceDTO.device_id}`,
+        `/api/plugin-proxy/kentik-connect-app/api/v5/device/${this.deviceDTO.device_id}`,
         data
       );
       if ('err' in resp) {

--- a/src/components/device_list.html
+++ b/src/components/device_list.html
@@ -4,7 +4,7 @@
 
 <div ng-if="!ctrl.pageReady" class="kentik-loading-message-container">
   <div class="kentik-loading-message-inside">
-    <img class="kentik-loading-pulse" src="public/plugins/kentik-app/img/loading-pulse.svg" style="margin-bottom: 10px;">
+    <img class="kentik-loading-pulse" src="public/plugins/kentik-connect-app/img/loading-pulse.svg" style="margin-bottom: 10px;">
     <p class="kentik-loading-msg-1">To infinity...and beyond.</p>
     <p class="kentik-loading-msg-2">This is taking longer than expected.</p>
     <p class="kentik-loading-msg-3">We apologize, something may be up. Please try refreshing first, and contact us if
@@ -17,7 +17,7 @@
     <div style="text-align: center; padding-top: 90px; min-height: 220px; min-width: 400px;  margin: 0 auto;">
       <i ng-class="icon" class="icon-gf icon-gf-endpoint no-endpoints"></i>
       <p>Looks like you don’t have any devices yet.<br>
-        <a class="highlight-word" href="plugins/kentik-app/pages/add-device">Add a new device</a>
+        <a class="highlight-word" href="plugins/kentik-connect-app/pages/add-device">Add a new device</a>
       </p>
     </div>
     <a href="#" ng-click="ctrl.showDeviceDesc = !ctrl.showDeviceDesc">
@@ -26,7 +26,7 @@
       <span ng-show="ctrl.showDeviceDesc">What's a device?</span>
       <span><i class="fa fa-caret-down" ng-show="ctrl.showDeviceDesc"></i></span>
     </a>
-    <div class="kentik-app-devicedesc-box" ng-class="{ 'kentik-app-devicedesc-open': ctrl.showDeviceDesc }">
+    <div class="kentik-connect-app-devicedesc-box" ng-class="{ 'kentik-connect-app-devicedesc-open': ctrl.showDeviceDesc }">
       <div class="kentik-collapse-blurb-box">
         <p class="kentik-helper-blurb">Devices in Kentik are sources of network flow data - commonly a network
           component such as a switch or router, or a flow generation agent on a host/server. </p>
@@ -46,7 +46,7 @@
           <a ng-click="$event.stopPropagation();" href="dashboard/db/kentik-top-talkers?var-device={{device.device_name}}">
             <i ng-class="icon" class="icon-gf icon-gf-dashboard" bs-tooltip="'Go to Top Talkers</br>dashboard for {{device.device_name}}'"></i>
           </a>
-          <a ng-click="$event.stopPropagation();" href="plugins/kentik-app/page/device-details?device={{device.id}}">
+          <a ng-click="$event.stopPropagation();" href="plugins/kentik-connect-app/page/device-details?device={{device.id}}">
             <i ng-class="icon" class="icon-gf icon-gf-settings" bs-tooltip="'Configure {{device.device_name}}'"></i>
           </a>
         </div>

--- a/src/components/device_list.ts
+++ b/src/components/device_list.ts
@@ -37,7 +37,7 @@ class DeviceListCtrl {
   }
 
   gotoDeviceDetail(device: any) {
-    this.$location.url('/plugins/kentik-app/page/device-details?device=' + device.id);
+    this.$location.url('/plugins/kentik-connect-app/page/device-details?device=' + device.id);
   }
 }
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -115,7 +115,7 @@ class KentikConfigCtrl {
     let dsID = NaN;
     _.forEach(results, ds => {
       // use the type
-      if (ds.type === 'kentik-ds') {
+      if (ds.type === 'kentik-connect-datasource') {
         foundKentikDS = true;
         dsID = ds.id;
         updateKentikDS = true;
@@ -135,7 +135,7 @@ class KentikConfigCtrl {
       // create datasource
       const kentik = {
         name: 'kentik',
-        type: 'kentik-ds',
+        type: 'kentik-connect-datasource',
         access: 'proxy',
         jsonData: this.appModel.jsonData,
       };

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -115,15 +115,16 @@ class KentikConfigCtrl {
     let dsID = NaN;
     _.forEach(results, ds => {
       // use the type
-      if (ds.type === 'kentik-connect-datasource') {
+      if (ds.type === 'kentik-connect-datasource' || ds.type === 'kentik-ds') {
         foundKentikDS = true;
         dsID = ds.id;
         updateKentikDS = true;
 
-        if (ds.jsonData.region !== this.appModel.jsonData.region) {
-          updateKentikDS = true;
-        }
-        if (ds.jsonData !== this.appModel.jsonData) {
+        if (
+          ds.type === 'kentik-ds' ||
+          ds.jsonData.region !== this.appModel.jsonData.region ||
+          ds.jsonData !== this.appModel.jsonData
+        ) {
           updateKentikDS = true;
         }
         return;

--- a/src/dashboards/kentik-home.json
+++ b/src/dashboards/kentik-home.json
@@ -122,7 +122,7 @@
       "list": []
     },
     "schemaVersion": 7,
-    "version": 3,
+    "version": 4,
     "revision": 2,
     "links": []
   }

--- a/src/dashboards/kentik-home.json
+++ b/src/dashboards/kentik-home.json
@@ -21,7 +21,7 @@
             "span": 7.5,
             "height": "415px",
             "title": "",
-            "type": "kentik-device-list"
+            "type": "kentik-devicelist-panel"
           },
           {
             "content": "",
@@ -42,7 +42,7 @@
             "id": 1,
             "span": 4,
             "title": "",
-            "type": "kentik-call-to-action"
+            "type": "kentik-calltoaction-panel"
           },
           {
             "content": "",

--- a/src/datasource/datasource.test.ts
+++ b/src/datasource/datasource.test.ts
@@ -45,7 +45,7 @@ function createDatasourceInstance(ctx: any, data: any) {
     get: () => {
       return Promise.resolve([
         {
-          type: 'kentik-ds',
+          type: 'kentik-connect-datasource',
           jsonData: {
             region: 'default',
           },

--- a/src/datasource/kentik_api.ts
+++ b/src/datasource/kentik_api.ts
@@ -10,7 +10,7 @@ export class KentikAPI {
   baseUrl: string;
   /** @ngInject */
   constructor(public backendSrv: BackendSrv, public $http: ng.IHttpService) {
-    this.baseUrl = '/api/plugin-proxy/kentik-app';
+    this.baseUrl = '/api/plugin-proxy/kentik-connect-app';
   }
 
   async getDevices(): Promise<any> {

--- a/src/datasource/kentik_proxy.test.ts
+++ b/src/datasource/kentik_proxy.test.ts
@@ -45,7 +45,7 @@ function getKentikProxyInstance(ctx: any, data: any) {
     get: () => {
       return Promise.resolve([
         {
-          type: 'kentik-ds',
+          type: 'kentik-connect-datasource',
           jsonData: {
             region: 'default',
           },

--- a/src/datasource/plugin.json
+++ b/src/datasource/plugin.json
@@ -1,7 +1,7 @@
 {
   "type": "datasource",
   "name": "Kentik DS",
-  "id": "kentik-ds",
+  "id": "kentik-connect-datasource",
 
   "metrics": true
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -8,8 +8,8 @@ import { AddDeviceCtrl } from './components/add_device';
 import { loadPluginCss } from 'grafana/app/plugins/sdk';
 
 loadPluginCss({
-  dark: 'plugins/kentik-app/styles/dark.css',
-  light: 'plugins/kentik-app/styles/light.css',
+  dark: 'plugins/kentik-connect-app/styles/dark.css',
+  light: 'plugins/kentik-connect-app/styles/light.css',
 });
 
 export { DeviceListCtrl, DeviceDetailsCtrl, AddDeviceCtrl, ConfigCtrl };

--- a/src/panel/call_to_action/module.html
+++ b/src/panel/call_to_action/module.html
@@ -1,4 +1,4 @@
-<img class="kentik-dash--cta-logo" src="public/plugins/kentik-app/img/kentik_logo.png">
+<img class="kentik-dash--cta-logo" src="public/plugins/kentik-connect-app/img/kentik_logo.png">
 <p class="kentik-dashboard-blurb">Kentik Connect Pro for Grafana allows you to quickly and easily add network activity
   visibility metrics to your Grafana dashboard. By leveraging the power of Kentik’s monitoring SaaS, you can enjoy
   rich, actionable insights into consumers of network bandwidth and anomalies that can affect application or service

--- a/src/panel/call_to_action/module.ts
+++ b/src/panel/call_to_action/module.ts
@@ -8,8 +8,8 @@ import * as _ from 'lodash';
 
 
 loadPluginCss({
-  dark: 'plugins/kentik-app/styles/dark.css',
-  light: 'plugins/kentik-app/styles/light.css',
+  dark: 'plugins/kentik-connect-app/styles/dark.css',
+  light: 'plugins/kentik-connect-app/styles/light.css',
 });
 
 const panelDefaults = {

--- a/src/panel/call_to_action/plugin.json
+++ b/src/panel/call_to_action/plugin.json
@@ -1,5 +1,5 @@
 {
   "type": "panel",
   "name": "Kentik Call To Action",
-  "id": "kentik-call-to-action"
+  "id": "kentik-calltoaction-panel"
 }

--- a/src/panel/device_list/module.html
+++ b/src/panel/device_list/module.html
@@ -4,7 +4,7 @@
 
 <div ng-if="!ctrl.pageReady" class="kentik-loading-message-container">
   <div class="kentik-loading-message-inside">
-    <img class="kentik-loading-pulse" src="public/plugins/kentik-app/img/loading-pulse.svg" style="margin-bottom: 10px;">
+    <img class="kentik-loading-pulse" src="public/plugins/kentik-connect-app/img/loading-pulse.svg" style="margin-bottom: 10px;">
     <p class="kentik-loading-msg-1">To infinity...and beyond.</p>
     <p class="kentik-loading-msg-2">This is taking longer than expected.</p>
     <p class="kentik-loading-msg-3">We apologize, something may be up. Please try refreshing first, and contact us if
@@ -16,7 +16,7 @@
   <div ng-if="ctrl.devices.length === 0" style="display: flex; flex-direction: column; align-items: center; justify-content: flex-start; height: 350px;">
     <div style="text-align: center; padding-top: 90px; min-height: 220px; min-width: 400px;  margin: 0 auto;">
       <i ng-class="icon" class="icon-gf icon-gf-endpoint no-endpoints"></i>
-      <p>Looks like you don’t have any endpoints yet. <a class="highlight-word" href="plugins/kentik-app/pages/add-device">Add
+      <p>Looks like you don’t have any endpoints yet. <a class="highlight-word" href="plugins/kentik-connect-app/pages/add-device">Add
           a device now.</a></p>
     </div>
     <div class="rt-collapse-container">
@@ -43,13 +43,13 @@
           <a href="dashboard/db/kentik-top-talkers?var-device={{device.device_name}}">
             <i ng-class="icon" class="icon-gf icon-gf-dashboard" bs-tooltip="'Go to Top Talkers</br>dashboard for {{device.device_name}}'"></i>
           </a>
-          <a href="plugins/kentik-app/page/device-details?device={{device.id}}">
+          <a href="plugins/kentik-connect-app/page/device-details?device={{device.id}}">
             <i ng-class="icon" class="icon-gf icon-gf-settings" bs-tooltip="'Configure {{device.device_name}}'"></i>
           </a>
         </div>
         <div class="card-item-body">
           <div class="card-item-details">
-            <a href="plugins/kentik-app/page/device-details?device={{device.id}}">
+            <a href="plugins/kentik-connect-app/page/device-details?device={{device.id}}">
               <div class="card-item-name">
                 {{device.device_name}}
               </div>

--- a/src/panel/device_list/module.ts
+++ b/src/panel/device_list/module.ts
@@ -9,8 +9,8 @@ import * as _ from 'lodash';
 
 
 loadPluginCss({
-  dark: 'plugins/kentik-app/styles/dark.css',
-  light: 'plugins/kentik-app/styles/light.css',
+  dark: 'plugins/kentik-connect-app/styles/dark.css',
+  light: 'plugins/kentik-connect-app/styles/light.css',
 });
 
 const panelDefaults = {
@@ -60,10 +60,10 @@ class DeviceListCtrl extends PanelCtrl {
   }
 
   gotoDeviceDetail(device: any) {
-    this.$location.url('/plugins/kentik-app/page/device-details?device=' + device.id);
+    this.$location.url('/plugins/kentik-connect-app/page/device-details?device=' + device.id);
   }
 }
 
-DeviceListCtrl.templateUrl = 'public/plugins/kentik-app/components/device_list.html';
+DeviceListCtrl.templateUrl = 'public/plugins/kentik-connect-app/components/device_list.html';
 
 export { DeviceListCtrl as PanelCtrl };

--- a/src/panel/device_list/plugin.json
+++ b/src/panel/device_list/plugin.json
@@ -1,5 +1,5 @@
 {
   "type": "panel",
   "name": "Kentik Device List",
-  "id": "kentik-device-list"
+  "id": "kentik-devicelist-panel"
 }

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -83,6 +83,7 @@
   ],
 
   "dependencies": {
+    "grafanaDependency": ">=6.1.0",
     "grafanaVersion": "6.1.x"
   }
 }

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -78,7 +78,7 @@
     },
     {
       "type": "datasource",
-      "name": "Kentik-ds"
+      "name": "Kentik Datasource"
     }
   ],
 

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -1,7 +1,7 @@
 {
   "type": "app",
   "name": "Kentik Connect Pro",
-  "id": "kentik-app",
+  "id": "kentik-connect-app",
 
   "routes": [
     {


### PR DESCRIPTION
This PR:
- packages the plugin according to [Grafana docs](https://grafana.com/docs/grafana/latest/developers/plugins/package-a-plugin/)
- updates plugin id to satisfy [Grafana convention](https://grafana.com/docs/grafana/v7.5/developers/plugins/legacy/review-guidelines/#pluginjson): `kentik-app` -> `kentik-connect-app`
- bumps version to 1.5.0 

Changes:
 - `.circleci/config.yml`: archive only `dist` folder instead of full plugin
 - `src/plugin.json`: add a new `grafanaDependency` [dependency](https://grafana.com/docs/grafana/latest/developers/plugins/metadata/#properties-1)
- update plugin id to satisfy the convention: `kentik-app` -> `kentik-connect-app`
- update all sub-plugins (datasource and panels) ids
- update repo urls in package.json and readme
- bump version to 1.5.0 
- update installation documentation